### PR TITLE
Removendo o Yaki-ten dos restaurantes

### DIFF
--- a/02-barao/comida.tex
+++ b/02-barao/comida.tex
@@ -241,9 +241,8 @@ restaurantes próximos à padaria.
 Na Av. 2 e proximidades, há o Aulus (mais caro no final de semana, sobretudo no
 domingo, porém costuma ter camarão à milanesa para fazer valer a pena; a
 marmita não possui tantas opções de carne e acompanhamentos, no entanto é
-um tamanho satisfatório e custa R\$ 15,75, bem mais em conta que o self-service)
-e, mais para cima na avenida, há o Yaki-Ten (comida chinesa por quilo, japonesa
-por pessoa).
+um tamanho satisfatório e custa R\$ 15,75, bem mais em conta que o self-service).
+
 % "Logo mais abaixo há o Ilha do Barão" não achei nenhuma informação sobre esse
 % lugar.. ele existe? - Nunca ouvi falar.
 


### PR DESCRIPTION
Restaurante fechou, hoje em dia funciona o Armazém da Cerveja no mesmo lugar.