### PR TITLE
Removendo a Tarifa Lazer

### DIFF
--- a/02-barao/transporte.tex
+++ b/02-barao/transporte.tex
@@ -146,10 +146,6 @@ identificar os ônibus) e um nome.
 A tarifa foi reajustada em dezembro de 2017 e custa R\$ 4,70 (aproximadamente
 um bandeco e meio).
 
-Todo mês, em dois domingos, os usuários do transporte público de Campinas podem
-usar os ônibus pagando metade da tarifa. É o Passe Lazer. O benefício vale
-apenas para passagens avulsas (sem cartão) e para o Bilhete Único Comum.
-
 Desde 2015, existe o Bilhete Único Universitário. Mais informações sobre ele
 podem ser obtidas na seção sobre ele mais abaixo.
 


### PR DESCRIPTION
benefício não existe mais há uma cota. http://g1.globo.com/sp/campinas-regiao/noticia/2017/01/apos-tres-anos-campinas-suspende-passe-lazer-para-reavaliar-beneficio.html

